### PR TITLE
Adding spam filter to beep boop.

### DIFF
--- a/zendesk_reports.py
+++ b/zendesk_reports.py
@@ -122,6 +122,10 @@ def get_tickets_between(start_time_t, end_time_t):
             if 'translation_advocate' in ticket['current_tags']:
                 continue
 
+            # We dont care about spam and dont want them to trigger alert
+            if 'spam' in ticket['current_tags']:
+                continue
+
             # Skip tickets created by user-support, since they are
             # submitted in batches and cause false alarms
             if 'Request created from:' in ticket['subject']:


### PR DESCRIPTION
## Summary:
We have seen the alert triggering due to zendesk spam.  Support tags
these tickets as spam.  We might still get alert if they dont classify
these as spam in time, but at least this should mitigate some of the
false positive for zendesk alert.

Issue: https://khanacademy.slack.com/archives/C16T2PZBL/p1629490202158200

## Test plan:

Deploy and :finger-crossed: