### PR TITLE
Convert the beep-boop scripts to run under python3.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # We need this package for parsing times given by GitHub's API.
-iso8601==0.1.4
+iso8601==2.1.0

--- a/util.py
+++ b/util.py
@@ -39,7 +39,7 @@ def poisson_cdf(actual, mean):
 
     p = (-mean).exp()
     cum_prob += p
-    for i in xrange(actual):
+    for i in range(actual):
         # We calculate the probability of each lesser value individually, and
         # sum as we go
         p *= mean
@@ -93,7 +93,7 @@ def retry(fn, description, should_retry_fn, retry_count=3):
     and returning True if we should retry or False else.  Of course we
     ignore should_retry_fn after retry_count retries.
     """
-    for i in xrange(1, retry_count):
+    for i in range(1, retry_count):
         try:
             return fn()
         except Exception as why:


### PR DESCRIPTION
## Summary:
I just ran the `2to3` tool.  It converted everything but the change
from getheader() to get(), which I sussed out from
https://github.com/fortra/impacket/issues/836

Issue: https://khanacademy.atlassian.net/browse/INFRA-9839

## Test plan:
I manually ran `./github_reports.py` without error.

To test zendesk, I copied over the ~/beep-boop/zendesk.cfg file from
toby to my local beep-boop directory, and then ran
`./zendesk_reports.py.` without error.