### PR TITLE
Fix the alert emoji for beep-boop.

### DIFF
--- a/util.py
+++ b/util.py
@@ -77,9 +77,7 @@ def merge_int_dicts(d1, d2):
 
 def send_to_slack(message, channel):
     alertlib.Alert(message, severity=logging.ERROR) \
-        .send_to_slack(channel, sender='beep-boop',
-                       icon_emoji=None,  # need to override default value
-                       icon_url='https://slack.global.ssl.fastly.net/9fa2/img/services/hubot_128.png')
+        .send_to_slack(channel, sender='beep-boop', icon_emoji='robot_face')
 
 
 def send_to_pagerduty(message, service):


### PR DESCRIPTION
## Summary:
We were trying to use a custom image, but that image doesn't exist --
I get a 404 trying to visit it.  And indeed, I see in slack that the
image is the default Alert Alligator:
   https://khanacademy.slack.com/archives/C8XGW76FQ/p1744380602721929
Booooring.

Now it is a beep-booping robot.

Issue: none

## Test plan:
Fingers crossed